### PR TITLE
CfgORBAT support

### DIFF
--- a/Debug/fn_markEchelon.sqf
+++ b/Debug/fn_markEchelon.sqf
@@ -8,14 +8,14 @@ private [
 ];
 
 try {
-	switch (toUpper _echelon) do {
-		case "II": {
+	switch (_echelon) do {
+		case "Battalion": {
 			_echelon_marker_type = "group_5";
 		};
-		case "I": {
+		case "Company": {
 			_echelon_marker_type = "group_4";
 		};
-		case "•••": {
+		case "Platoon": {
 			_echelon_marker_type = "group_3";
 		};
 		default {

--- a/Debug/fn_markRadii.sqf
+++ b/Debug/fn_markRadii.sqf
@@ -15,22 +15,22 @@ private [
 if (_name == "") then { _name = str _pos; };
 
 try {
-	switch (toUpper _echelon) do {
-		case "II": {
+	switch (_echelon) do {
+		case "Battalion": {
 			_sibling_buffer_colour = "Default";
 			_sibling_buffer_radius = 8000;
 			_child_area_colour = "ColorRed";
 			_child_area_max_radius = 3000;
 			_child_area_min_radius = 1000;
 		};
-		case "I": {
+		case "Company": {
 			_sibling_buffer_colour = "ColorRed";
 			_sibling_buffer_radius = 2000;
 			_child_area_colour = "ColorBlue";
 			_child_area_max_radius = 2000;
 			_child_area_min_radius = 500;
 		};
-		case "•••": {
+		case "Platoon": {
 			_sibling_buffer_colour = "ColorBlue";
 			_sibling_buffer_radius = 600;
 			_child_area_colour = "ColorBlack";

--- a/SimTools_ForceDeployment.cpp
+++ b/SimTools_ForceDeployment.cpp
@@ -7,6 +7,7 @@ class SimTools_ForceDeployment
 		class deployForce {};
 		class findSafePos {};
 		class findValidPos {};
+		class Formation {};
 		class parseCfgOrbat {};
 	};
 	class ForceDeployment_Debug {

--- a/SimTools_ForceDeployment.cpp
+++ b/SimTools_ForceDeployment.cpp
@@ -7,6 +7,7 @@ class SimTools_ForceDeployment
 		class deployForce {};
 		class findSafePos {};
 		class findValidPos {};
+		class parseCfgOrbat {};
 	};
 	class ForceDeployment_Debug {
 		file = "SimTools\ForceDeployment\Debug";

--- a/fn_Formation.sqf
+++ b/fn_Formation.sqf
@@ -1,0 +1,34 @@
+params [
+	["_size", "", [""]],
+	["_position", [], [[0]]],
+	["_subordinates", [], [[]]]
+];
+
+private _fnc_typeCheck = {
+	params [
+		["_size", "", [""]],
+		["_position", [], [[0]]],
+		["_subordinates", [], [[]]]
+	];
+
+	private _cfgSize = configfile >> "CfgChainOfCommand" >> "Sizes" >> _size;
+	if (!isClass _cfgSize) exitWith {
+		["'%1' is not a valid formation size, at %2", _size, _this] call BIS_fnc_error;
+		false
+	};
+
+	if (!(count _position == 0 || count _position == 3) && {_position pushback 0; count _position != 3}) exitWith {
+		["'%1' is not a valid position, at %2", _position, _this] call BIS_fnc_error;
+		false
+	};
+
+	if ((_subordinates apply {_x call _fnc_typeCheck}) findIf {!_x} > 1) exitWith {
+		false
+	};
+
+	true
+};
+
+if (!(_this call _fnc_typeCheck)) exitWith { nil };
+
+[_size, _position, _subordinates]

--- a/fn_deployForce.sqf
+++ b/fn_deployForce.sqf
@@ -57,10 +57,10 @@ switchOnEchelon = {
 		]
 	];
 
-	switch (toUpper _echelon) do {
-		case "II": _BNCode;
-		case "I": _COYCode;
-		case "•••": _PLCode;
+	switch (_echelon) do {
+		case "Battalion": _BNCode;
+		case "Company": _COYCode;
+		case "Platoon": _PLCode;
 		default _defaultCode;
 	};
 };
@@ -75,7 +75,7 @@ private _pbBacklist = [];
 		_x select 1,
 		_x select 2
 	];
-	if (_x select 0 == "•••") then {
+	if (_x select 0 == "Platoon") then {
 		_next pushBack _pbBacklist;
 	};
 	_next call {

--- a/fn_deployForce.sqf
+++ b/fn_deployForce.sqf
@@ -127,7 +127,7 @@ private _pbBacklist = [];
 			_pos set [1, _newPos select 1];
 			if (count _newPos < 3) then { _pos pushBack 0; };
 
-			if (toUpper _echelon == "I") then {
+			if (_echelon == "Company") then {
 				private _vector = (_pos vectorFromTo _parentPos);
 				_vector = _vector vectorMultiply 1000;
 				private _dir = (_vector select 0) atan2 (_vector select 1);

--- a/fn_parseCfgOrbat.sqf
+++ b/fn_parseCfgOrbat.sqf
@@ -11,11 +11,11 @@ private _fnc_traverseSubclasses = {
 
 	private _subordinates = getArray (_class >> "subordinates");
 	if (count _subordinates < 1 && {_subordinates = _class call BIS_fnc_returnChildren; count _subordinates < 1}) exitWith {
-		[getText (_class >> "size"), getArray (_class >> "position"), []]
+		[getText (_class >> "size"), getArray (_class >> "position")] call SimTools_ForceDeployment_fnc_Formation
 	};
 
 	_subordinates = _subordinates apply {[_x] call _fnc_traverseSubclasses};
-	[getText (_class >> "size"), getArray (_class >> "position"), _subordinates];
+	[getText (_class >> "size"), getArray (_class >> "position"), _subordinates] call SimTools_ForceDeployment_fnc_Formation
 };
 
 _orbats apply {[_x] call _fnc_traverseSubclasses}

--- a/fn_parseCfgOrbat.sqf
+++ b/fn_parseCfgOrbat.sqf
@@ -1,0 +1,21 @@
+params [
+	["_config", getMissionConfig "CfgORBAT", [configNull]]
+];
+
+private _orbats = "true" configClasses _config;
+
+private _fnc_traverseSubclasses = {
+	params [
+		["_class", configNull, [configNull]]
+	];
+
+	private _subordinates = getArray (_class >> "subordinates");
+	if (count _subordinates < 1 && {_subordinates = _class call BIS_fnc_returnChildren; count _subordinates < 1}) exitWith {
+		[getText (_class >> "size"), getArray (_class >> "position"), []]
+	};
+
+	_subordinates = _subordinates apply {[_x] call _fnc_traverseSubclasses};
+	[getText (_class >> "size"), getArray (_class >> "position"), _subordinates];
+};
+
+_orbats apply {[_x] call _fnc_traverseSubclasses}


### PR DESCRIPTION
These changes will allow using `CfgORBAT` class hierarchy from the [ORBAT Viewer](https://community.bistudio.com/wiki/ORBAT_Viewer) module to initialize the force deployment module. This resolves #12.

- [x] Convert `CfgORBAT` classes into the force deployment data structure.
- [x] Update force deployment scripts to expect `CfgChainOfCommand >> Sizes` as "enums" corresponding to the formation echelon.
- [x] Support set (seeded) initial positions.